### PR TITLE
FLEX-3850 ~ Removes logging of organization for incoming OSLP messages.

### DIFF
--- a/osgp-adapter-protocol-oslp-elster/src/main/java/com/alliander/osgp/adapter/protocol/oslp/elster/infra/networking/OslpChannelHandler.java
+++ b/osgp-adapter-protocol-oslp-elster/src/main/java/com/alliander/osgp/adapter/protocol/oslp/elster/infra/networking/OslpChannelHandler.java
@@ -27,7 +27,6 @@ import com.alliander.osgp.adapter.protocol.oslp.elster.domain.repositories.OslpD
 import com.alliander.osgp.adapter.protocol.oslp.elster.infra.messaging.OslpLogItemRequestMessage;
 import com.alliander.osgp.adapter.protocol.oslp.elster.infra.messaging.OslpLogItemRequestMessageSender;
 import com.alliander.osgp.core.db.api.application.services.DeviceDataService;
-import com.alliander.osgp.core.db.api.entities.Device;
 import com.alliander.osgp.oslp.Oslp;
 import com.alliander.osgp.oslp.OslpEnvelope;
 
@@ -107,7 +106,6 @@ public abstract class OslpChannelHandler extends SimpleChannelHandler {
 
         final String deviceUid = Base64.encodeBase64String(message.getDeviceId());
         String deviceIdentification = this.getDeviceIdentificationFromMessage(message.getPayloadMessage());
-        String organisationIdentification = null;
 
         // Assume outgoing messages always valid.
         final boolean isValid = incoming ? message.isValid() : true;
@@ -118,17 +116,10 @@ public abstract class OslpChannelHandler extends SimpleChannelHandler {
             if (oslpDevice != null) {
                 deviceIdentification = oslpDevice.getDeviceIdentification();
             }
-
-            // Getting the organisationIdentification from the Device instance
-            final Device device = this.deviceDataService.findDevice(deviceIdentification);
-            if (device != null) {
-                organisationIdentification = device.getOrganisation().getOrganisationIdentification();
-            }
         }
 
-        final OslpLogItemRequestMessage oslpLogItemRequestMessage = new OslpLogItemRequestMessage(
-                organisationIdentification, deviceUid, deviceIdentification, incoming, isValid,
-                message.getPayloadMessage(), message.getSize());
+        final OslpLogItemRequestMessage oslpLogItemRequestMessage = new OslpLogItemRequestMessage(null, deviceUid,
+                deviceIdentification, incoming, isValid, message.getPayloadMessage(), message.getSize());
 
         this.oslpLogItemRequestMessageSender.send(oslpLogItemRequestMessage);
     }

--- a/osgp-adapter-protocol-oslp/src/main/java/com/alliander/osgp/adapter/protocol/oslp/infra/networking/OslpChannelHandler.java
+++ b/osgp-adapter-protocol-oslp/src/main/java/com/alliander/osgp/adapter/protocol/oslp/infra/networking/OslpChannelHandler.java
@@ -27,7 +27,6 @@ import com.alliander.osgp.adapter.protocol.oslp.domain.repositories.OslpDeviceRe
 import com.alliander.osgp.adapter.protocol.oslp.infra.messaging.OslpLogItemRequestMessage;
 import com.alliander.osgp.adapter.protocol.oslp.infra.messaging.OslpLogItemRequestMessageSender;
 import com.alliander.osgp.core.db.api.application.services.DeviceDataService;
-import com.alliander.osgp.core.db.api.entities.Device;
 import com.alliander.osgp.oslp.Oslp;
 import com.alliander.osgp.oslp.OslpEnvelope;
 
@@ -107,7 +106,6 @@ public abstract class OslpChannelHandler extends SimpleChannelHandler {
 
         final String deviceUid = Base64.encodeBase64String(message.getDeviceId());
         String deviceIdentification = this.getDeviceIdentificationFromMessage(message.getPayloadMessage());
-        String organisationIdentification = null;
 
         // Assume outgoing messages always valid.
         final boolean isValid = incoming ? message.isValid() : true;
@@ -118,17 +116,10 @@ public abstract class OslpChannelHandler extends SimpleChannelHandler {
             if (oslpDevice != null) {
                 deviceIdentification = oslpDevice.getDeviceIdentification();
             }
-
-            // Getting the organisationIdentification from the Device instance
-            final Device device = this.deviceDataService.findDevice(deviceIdentification);
-            if (device != null) {
-                organisationIdentification = device.getOrganisation().getOrganisationIdentification();
-            }
         }
 
-        final OslpLogItemRequestMessage oslpLogItemRequestMessage = new OslpLogItemRequestMessage(
-                organisationIdentification, deviceUid, deviceIdentification, incoming, isValid,
-                message.getPayloadMessage(), message.getSize());
+        final OslpLogItemRequestMessage oslpLogItemRequestMessage = new OslpLogItemRequestMessage(null, deviceUid,
+                deviceIdentification, incoming, isValid, message.getPayloadMessage(), message.getSize());
 
         this.oslpLogItemRequestMessageSender.send(oslpLogItemRequestMessage);
     }


### PR DESCRIPTION
- messageReceived() calls logMessage()
- logMessage() determines the owner organization or authorized
organization and logs it
- the organization identification is only relevant for outgoing OSLP messages, not for
incoming messages