### PR TITLE
FLEX-3995 ~ Uses map containing test device IDs and test device IPs.

### DIFF
--- a/osgp-adapter-protocol-oslp-elster/src/main/java/com/alliander/osgp/adapter/protocol/oslp/elster/application/config/OslpConfig.java
+++ b/osgp-adapter-protocol-oslp-elster/src/main/java/com/alliander/osgp/adapter/protocol/oslp/elster/application/config/OslpConfig.java
@@ -78,8 +78,8 @@ public class OslpConfig extends AbstractConfig {
         final ChannelPipelineFactory pipelineFactory = new ChannelPipelineFactory() {
             @Override
             public ChannelPipeline getPipeline() throws ProtocolAdapterException {
-                final ChannelPipeline pipeline = OslpConfig.this.createChannelPipeline(OslpConfig.this
-                        .oslpChannelHandlerClient());
+                final ChannelPipeline pipeline = OslpConfig.this
+                        .createChannelPipeline(OslpConfig.this.oslpChannelHandlerClient());
 
                 LOGGER.info("Created client new pipeline");
 
@@ -108,8 +108,8 @@ public class OslpConfig extends AbstractConfig {
         bootstrap.setPipelineFactory(new ChannelPipelineFactory() {
             @Override
             public ChannelPipeline getPipeline() throws ProtocolAdapterException {
-                final ChannelPipeline pipeline = OslpConfig.this.createChannelPipeline(OslpConfig.this
-                        .oslpChannelHandlerServer());
+                final ChannelPipeline pipeline = OslpConfig.this
+                        .createChannelPipeline(OslpConfig.this.oslpChannelHandlerServer());
 
                 LOGGER.info("Created server new pipeline");
 
@@ -210,8 +210,8 @@ public class OslpConfig extends AbstractConfig {
 
     @Bean
     public boolean executeResumeScheduleAfterSetLight() {
-        return Boolean.parseBoolean(this.environment
-                .getRequiredProperty(PROPERTY_NAME_OSLP_EXECUTE_RESUME_SCHEDULE_AFTER_SET_LIGHT));
+        return Boolean.parseBoolean(
+                this.environment.getRequiredProperty(PROPERTY_NAME_OSLP_EXECUTE_RESUME_SCHEDULE_AFTER_SET_LIGHT));
     }
 
     @Bean
@@ -222,19 +222,5 @@ public class OslpConfig extends AbstractConfig {
     @Bean
     public Float defaultLongitude() {
         return Float.parseFloat(this.environment.getRequiredProperty(PROPERTY_NAME_OSLP_DEFAULT_LONGITUDE));
-    }
-
-    @Bean
-    public String testDeviceId() {
-        final String testDeviceId = this.environment.getProperty("test.device.id");
-        LOGGER.info("testDeviceId: {}", testDeviceId);
-        return testDeviceId;
-    }
-
-    @Bean
-    public String testDeviceIp() {
-        final String testDeviceIp = this.environment.getProperty("test.device.ip");
-        LOGGER.info("testDeviceIp: {}", testDeviceIp);
-        return testDeviceIp;
     }
 }

--- a/osgp-adapter-protocol-oslp-elster/src/main/java/com/alliander/osgp/adapter/protocol/oslp/elster/infra/networking/OslpChannelHandlerServer.java
+++ b/osgp-adapter-protocol-oslp-elster/src/main/java/com/alliander/osgp/adapter/protocol/oslp/elster/infra/networking/OslpChannelHandlerServer.java
@@ -9,6 +9,7 @@ package com.alliander.osgp.adapter.protocol.oslp.elster.infra.networking;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -22,6 +23,7 @@ import org.joda.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 
 import com.alliander.osgp.adapter.protocol.oslp.elster.application.services.DeviceManagementService;
 import com.alliander.osgp.adapter.protocol.oslp.elster.application.services.DeviceRegistrationService;
@@ -63,12 +65,6 @@ public class OslpChannelHandlerServer extends OslpChannelHandler {
     private Float defaultLongitude;
 
     @Autowired
-    private String testDeviceId;
-
-    @Autowired
-    private String testDeviceIp;
-
-    @Autowired
     private OslpDeviceSettingsService oslpDeviceSettingsService;
 
     @Autowired
@@ -76,6 +72,9 @@ public class OslpChannelHandlerServer extends OslpChannelHandler {
 
     @Autowired
     private OslpSigningService oslpSigningService;
+
+    @Value("#{${test.device.ips}}")
+    private Map<String, String> testDeviceIps;
 
     private final ConcurrentMap<Integer, Channel> channelMap = new ConcurrentHashMap<>();
 
@@ -135,8 +134,8 @@ public class OslpChannelHandlerServer extends OslpChannelHandler {
                     payload = this.handleEventNotificationRequest(message.getDeviceId(), message.getSequenceNumber(),
                             message.getPayloadMessage().getEventNotificationRequest());
                 } else {
-                    LOGGER.warn("{} Received unknown payload. Received: {}.", channelId, message.getPayloadMessage()
-                            .toString());
+                    LOGGER.warn("{} Received unknown payload. Received: {}.", channelId,
+                            message.getPayloadMessage().toString());
                     // Optional extra: return error code to device.
                     return;
                 }
@@ -164,8 +163,8 @@ public class OslpChannelHandlerServer extends OslpChannelHandler {
     public void processSignedOslpEnvelope(final SignedOslpEnvelopeDto signedOslpEnvelopeDto) {
 
         // Try to find the channel.
-        final Integer channelId = Integer.parseInt(signedOslpEnvelopeDto.getUnsignedOslpEnvelopeDto()
-                .getCorrelationUid());
+        final Integer channelId = Integer
+                .parseInt(signedOslpEnvelopeDto.getUnsignedOslpEnvelopeDto().getCorrelationUid());
         final Channel channel = this.findChannel(channelId);
         if (channel == null) {
             LOGGER.error("Unable to find channel for channelId: {}. Can't send response message to device.", channelId);
@@ -185,9 +184,10 @@ public class OslpChannelHandlerServer extends OslpChannelHandler {
 
         final String deviceIdentification = registerRequest.getDeviceIdentification();
         InetAddress inetAddress = InetAddress.getByAddress(registerRequest.getIpAddress().toByteArray());
-        if (this.testDeviceId != null && this.testDeviceIp != null && deviceIdentification.equals(this.testDeviceId)) {
-            LOGGER.info("Using testDeviceId: {} and testDeviceIp: {}", this.testDeviceId, this.testDeviceIp);
-            inetAddress = InetAddress.getByName(this.testDeviceIp);
+        if (this.testDeviceIps != null && this.testDeviceIps.containsKey(deviceIdentification)) {
+            final String testDeviceIp = this.testDeviceIps.get(deviceIdentification);
+            LOGGER.info("Using testDeviceId: {} and testDeviceIp: {}", deviceIdentification, testDeviceIp);
+            inetAddress = InetAddress.getByName(testDeviceIp);
         }
         final String deviceType = registerRequest.getDeviceType().toString();
         final boolean hasSchedule = registerRequest.getHasSchedule();
@@ -197,8 +197,8 @@ public class OslpChannelHandlerServer extends OslpChannelHandler {
         this.deviceRegistrationService.sendDeviceRegisterRequest(inetAddress, deviceType, hasSchedule,
                 deviceIdentification);
 
-        OslpDevice oslpDevice = this.oslpDeviceSettingsService.getDeviceByDeviceIdentification(registerRequest
-                .getDeviceIdentification());
+        OslpDevice oslpDevice = this.oslpDeviceSettingsService
+                .getDeviceByDeviceIdentification(registerRequest.getDeviceIdentification());
 
         // Save the security related values in the OSLP database.
         oslpDevice.updateRegistrationData(deviceUid, registerRequest.getDeviceType().toString(),
@@ -222,11 +222,11 @@ public class OslpChannelHandlerServer extends OslpChannelHandler {
         if (gpsCoordinates != null && gpsCoordinates.getLatitude() != null && gpsCoordinates.getLongitude() != null) {
             // Add GPS information when available in meta data.
             locationInfo.setLatitude(this.convertGpsCoordinateFromFloatToInt(gpsCoordinates.getLatitude()))
-            .setLongitude(this.convertGpsCoordinateFromFloatToInt(gpsCoordinates.getLongitude()));
+                    .setLongitude(this.convertGpsCoordinateFromFloatToInt(gpsCoordinates.getLongitude()));
         } else {
             // Otherwise use default GPS information.
-            locationInfo.setLatitude(this.convertGpsCoordinateFromFloatToInt(this.defaultLatitude)).setLongitude(
-                    this.convertGpsCoordinateFromFloatToInt(this.defaultLongitude));
+            locationInfo.setLatitude(this.convertGpsCoordinateFromFloatToInt(this.defaultLatitude))
+                    .setLongitude(this.convertGpsCoordinateFromFloatToInt(this.defaultLongitude));
         }
 
         responseBuilder.setLocationInfo(locationInfo);
@@ -250,13 +250,12 @@ public class OslpChannelHandlerServer extends OslpChannelHandler {
             throw new ProtocolAdapterException("ConfirmRegisterDevice failed", e);
         }
 
-        return Oslp.Message
-                .newBuilder()
-                .setConfirmRegisterDeviceResponse(
-                        Oslp.ConfirmRegisterDeviceResponse.newBuilder().setStatus(Oslp.Status.OK)
-                        .setRandomDevice(confirmRegisterDeviceRequest.getRandomDevice())
+        return Oslp.Message.newBuilder()
+                .setConfirmRegisterDeviceResponse(Oslp.ConfirmRegisterDeviceResponse.newBuilder()
+                        .setStatus(Oslp.Status.OK).setRandomDevice(confirmRegisterDeviceRequest.getRandomDevice())
                         .setRandomPlatform(confirmRegisterDeviceRequest.getRandomPlatform())
-                        .setSequenceWindow(this.sequenceNumberWindow)).build();
+                        .setSequenceWindow(this.sequenceNumberWindow))
+                .build();
     }
 
     private Oslp.Message handleEventNotificationRequest(final byte[] deviceId, final byte[] sequenceNumber,
@@ -268,10 +267,8 @@ public class OslpChannelHandlerServer extends OslpChannelHandler {
                     SequenceNumberUtils.convertByteArrayToInteger(sequenceNumber));
         } catch (final ProtocolAdapterException ex) {
             LOGGER.error("handle event notification request exception", ex);
-            return Oslp.Message
-                    .newBuilder()
-                    .setEventNotificationResponse(
-                            Oslp.EventNotificationResponse.newBuilder().setStatus(Oslp.Status.REJECTED)).build();
+            return Oslp.Message.newBuilder().setEventNotificationResponse(
+                    Oslp.EventNotificationResponse.newBuilder().setStatus(Oslp.Status.REJECTED)).build();
         }
 
         final Oslp.Status oslpStatus = Oslp.Status.OK;

--- a/osgp-adapter-protocol-oslp-elster/src/main/resources/osgp-adapter-protocol-oslp-elster.properties
+++ b/osgp-adapter-protocol-oslp-elster/src/main/resources/osgp-adapter-protocol-oslp-elster.properties
@@ -275,14 +275,4 @@ jms.signing.server.responses.use.exponential.back.off=true
 # Example:
 # test.device.ips={'ELS-001':'10.0.0.1','ELS-002':'10.0.0.2'}
 #
-# The list can be converted to a java.util.Map<String,String> using the @Value annotation
-# and Spring Expression Language.
-#
-# Example:
-#    @Value("#{${test.device.ips}}")
-#    private Map<String, String> testDeviceIps;
-#
-# See the SpEL documentation for more information:
-# https://docs.spring.io/spring/docs/3.0.x/reference/expressions.html
-#
 test.device.ips=null

--- a/osgp-adapter-protocol-oslp-elster/src/main/resources/osgp-adapter-protocol-oslp-elster.properties
+++ b/osgp-adapter-protocol-oslp-elster/src/main/resources/osgp-adapter-protocol-oslp-elster.properties
@@ -259,3 +259,30 @@ jms.signing.server.responses.back.off.multiplier=2
 jms.signing.server.responses.use.exponential.back.off=true
 
 # =========================================================
+
+
+
+# =========================================================
+#  Test Devices IP Addresses
+# =========================================================
+#
+# The property 'test.device.ips' can be used to define IP addresses for switching devices.
+# The property is not optional. Use 'null' as default value: 'test.device.ips=null'.
+#
+# Format:
+# {'device-identification-1':'ip-address-1','device-identification-2':'ip-address-2',...}
+#
+# Example:
+# test.device.ips={'ELS-001':'10.0.0.1','ELS-002':'10.0.0.2'}
+#
+# The list can be converted to a java.util.Map<String,String> using the @Value annotation
+# and Spring Expression Language.
+#
+# Example:
+#    @Value("#{${test.device.ips}}")
+#    private Map<String, String> testDeviceIps;
+#
+# See the SpEL documentation for more information:
+# https://docs.spring.io/spring/docs/3.0.x/reference/expressions.html
+#
+test.device.ips=null


### PR DESCRIPTION
- removed the 'testDeviceId' and 'testDeviceIp' properties
- added new 'testDeviceIps' property
- the new property can contain multiple IDs and IPs, so testing with
multiple devices becomes easier
- the new property is not optional; if not set, the protocol-adapter
component will not start