### PR TITLE
SLIM-1534 Refactors code throwing exceptions to resolve SQ issues

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "Shared"]
 	path = Shared
 	url = https://github.com/OSGP/Shared.git
-	branch = development
+	branch = SLIM-1534-refactor-throw-at-most-one-checked-exception

--- a/signing-server/src/main/java/com/alliander/osgp/signing/server/application/config/ApplicationContext.java
+++ b/signing-server/src/main/java/com/alliander/osgp/signing/server/application/config/ApplicationContext.java
@@ -8,10 +8,7 @@
 package com.alliander.osgp.signing.server.application.config;
 
 import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
-import java.security.spec.InvalidKeySpecException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,6 +20,7 @@ import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.PropertySources;
 
 import com.alliander.osgp.shared.application.config.AbstractConfig;
+import com.alliander.osgp.shared.exceptionhandling.EncrypterException;
 import com.alliander.osgp.shared.security.CertificateHelper;
 import com.alliander.osgp.signing.server.domain.exceptions.SigningServerException;
 
@@ -51,7 +49,7 @@ public class ApplicationContext extends AbstractConfig {
                     this.environment.getRequiredProperty(PROPERTY_NAME_SIGNING_SERVER_SECURITY_SIGNKEY_PATH),
                     this.environment.getRequiredProperty(PROPERTY_NAME_SIGNING_SERVER_SECURITY_KEYTYPE),
                     this.environment.getRequiredProperty(PROPERTY_NAME_SIGNING_SERVER_SECURITY_PROVIDER));
-        } catch (NoSuchAlgorithmException | InvalidKeySpecException | IOException | NoSuchProviderException e) {
+        } catch (EncrypterException | IOException e) {
             final String msg = "Error creating private key bean";
             LOGGER.error(msg, e);
             throw new SigningServerException(msg, e);

--- a/web-device-simulator/src/main/java/com/alliander/osgp/webdevicesimulator/application/config/ApplicationContext.java
+++ b/web-device-simulator/src/main/java/com/alliander/osgp/webdevicesimulator/application/config/ApplicationContext.java
@@ -9,11 +9,8 @@ package com.alliander.osgp.webdevicesimulator.application.config;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.security.spec.InvalidKeySpecException;
 import java.util.Properties;
 import java.util.concurrent.Executors;
 
@@ -263,16 +260,10 @@ public class ApplicationContext {
         final ChannelFactory factory = new NioClientSocketChannelFactory(Executors.newCachedThreadPool(),
                 Executors.newCachedThreadPool());
 
-        final ChannelPipelineFactory pipelineFactory = new ChannelPipelineFactory() {
-            @Override
-            public ChannelPipeline getPipeline()
-                    throws InvalidKeySpecException, NoSuchAlgorithmException, IOException, NoSuchProviderException {
-                final ChannelPipeline pipeline = ApplicationContext.this.createPipeLine();
-
-                LOGGER.info("Created new client pipeline");
-
-                return pipeline;
-            }
+        final ChannelPipelineFactory pipelineFactory = () -> {
+            final ChannelPipeline pipeline = ApplicationContext.this.createPipeLine();
+            LOGGER.info("Created new client pipeline");
+            return pipeline;
         };
 
         final ClientBootstrap bootstrap = new ClientBootstrap(factory);
@@ -293,15 +284,10 @@ public class ApplicationContext {
 
         final ServerBootstrap bootstrap = new ServerBootstrap(factory);
 
-        bootstrap.setPipelineFactory(new ChannelPipelineFactory() {
-            @Override
-            public ChannelPipeline getPipeline()
-                    throws InvalidKeySpecException, NoSuchAlgorithmException, IOException, NoSuchProviderException {
-                final ChannelPipeline pipeline = ApplicationContext.this.createPipeLine();
-                LOGGER.info("Created new server pipeline");
-
-                return pipeline;
-            }
+        bootstrap.setPipelineFactory(() -> {
+            final ChannelPipeline pipeline = ApplicationContext.this.createPipeLine();
+            LOGGER.info("Created new server pipeline");
+            return pipeline;
         });
 
         bootstrap.setOption("child.tcpNoDelay", true);
@@ -319,15 +305,10 @@ public class ApplicationContext {
 
         final ServerBootstrap bootstrap = new ServerBootstrap(factory);
 
-        bootstrap.setPipelineFactory(new ChannelPipelineFactory() {
-            @Override
-            public ChannelPipeline getPipeline()
-                    throws InvalidKeySpecException, NoSuchAlgorithmException, IOException, NoSuchProviderException {
-                final ChannelPipeline pipeline = ApplicationContext.this.createPipeLine();
-                LOGGER.info("Created new server pipeline");
-
-                return pipeline;
-            }
+        bootstrap.setPipelineFactory(() -> {
+            final ChannelPipeline pipeline = ApplicationContext.this.createPipeLine();
+            LOGGER.info("Created new server pipeline");
+            return pipeline;
         });
 
         bootstrap.setOption("child.tcpNoDelay", true);
@@ -338,8 +319,7 @@ public class ApplicationContext {
         return bootstrap;
     }
 
-    private ChannelPipeline createPipeLine()
-            throws NoSuchAlgorithmException, InvalidKeySpecException, NoSuchProviderException, IOException {
+    private ChannelPipeline createPipeLine() {
         final ChannelPipeline pipeline = Channels.pipeline();
 
         pipeline.addLast("oslpEncoder", new OslpEncoder());
@@ -356,14 +336,12 @@ public class ApplicationContext {
     }
 
     @Bean
-    public OslpDecoder oslpDecoder()
-            throws InvalidKeySpecException, NoSuchAlgorithmException, IOException, NoSuchProviderException {
+    public OslpDecoder oslpDecoder() {
         return new OslpDecoder(this.oslpSignature(), this.oslpSignatureProvider());
     }
 
     @Bean
-    public PublicKey publicKey()
-            throws NoSuchAlgorithmException, IOException, InvalidKeySpecException, NoSuchProviderException {
+    public PublicKey publicKey() throws IOException {
         return CertificateHelper.createPublicKey(
                 this.environment.getProperty(PROPERTY_NAME_OSLP_SECURITY_VERIFYKEY_PATH),
                 this.environment.getProperty(PROPERTY_NAME_OSLP_SECURITY_KEYTYPE),
@@ -371,8 +349,7 @@ public class ApplicationContext {
     }
 
     @Bean
-    public PrivateKey privateKey()
-            throws IOException, InvalidKeySpecException, NoSuchAlgorithmException, NoSuchProviderException {
+    public PrivateKey privateKey() throws IOException {
         return CertificateHelper.createPrivateKey(
                 this.environment.getProperty(PROPERTY_NAME_OSLP_SECURITY_SIGNKEY_PATH),
                 this.environment.getProperty(PROPERTY_NAME_OSLP_SECURITY_KEYTYPE),

--- a/web-device-simulator/src/main/java/com/alliander/osgp/webdevicesimulator/application/config/ApplicationContext.java
+++ b/web-device-simulator/src/main/java/com/alliander/osgp/webdevicesimulator/application/config/ApplicationContext.java
@@ -79,7 +79,7 @@ public class ApplicationContext {
     private static final String VIEW_RESOLVER_SUFFIX = ".jsp";
 
     private static final String PROPERTY_NAME_DATABASE_DRIVER = "db.driver";
-    private static final String PROPERTY_NAME_DATABASE_PASSWORD = "db.password";
+    private static final String PROPERTY_NAME_DATABASE_PW = "db.password";
     private static final String PROPERTY_NAME_DATABASE_URL = "db.url";
     private static final String PROPERTY_NAME_DATABASE_USERNAME = "db.username";
 
@@ -146,7 +146,7 @@ public class ApplicationContext {
             hikariConfig.setDriverClassName(this.environment.getRequiredProperty(PROPERTY_NAME_DATABASE_DRIVER));
             hikariConfig.setJdbcUrl(this.environment.getRequiredProperty(PROPERTY_NAME_DATABASE_URL));
             hikariConfig.setUsername(this.environment.getRequiredProperty(PROPERTY_NAME_DATABASE_USERNAME));
-            hikariConfig.setPassword(this.environment.getRequiredProperty(PROPERTY_NAME_DATABASE_PASSWORD));
+            hikariConfig.setPassword(this.environment.getRequiredProperty(PROPERTY_NAME_DATABASE_PW));
 
             hikariConfig.setMaximumPoolSize(
                     Integer.parseInt(this.environment.getRequiredProperty(PROPERTY_NAME_DATABASE_MAX_POOL_SIZE)));
@@ -199,7 +199,7 @@ public class ApplicationContext {
      */
     @Bean
     @DependsOn("flyway")
-    public LocalContainerEntityManagerFactoryBean entityManagerFactory() throws ClassNotFoundException {
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
         final LocalContainerEntityManagerFactoryBean entityManagerFactoryBean = new LocalContainerEntityManagerFactoryBean();
 
         entityManagerFactoryBean.setPersistenceUnitName("OSPG_DEVICESIMULATOR_WEB");

--- a/web-device-simulator/src/main/java/com/alliander/osgp/webdevicesimulator/application/config/ApplicationContext.java
+++ b/web-device-simulator/src/main/java/com/alliander/osgp/webdevicesimulator/application/config/ApplicationContext.java
@@ -162,11 +162,9 @@ public class ApplicationContext {
      * Method for creating the Transaction Manager.
      *
      * @return JpaTransactionManager
-     * @throws ClassNotFoundException
-     *             when class not found
      */
     @Bean
-    public JpaTransactionManager transactionManager() throws ClassNotFoundException {
+    public JpaTransactionManager transactionManager() {
         final JpaTransactionManager transactionManager = new JpaTransactionManager();
 
         transactionManager.setEntityManagerFactory(this.entityManagerFactory().getObject());
@@ -194,8 +192,6 @@ public class ApplicationContext {
      * Method for creating the Entity Manager Factory Bean.
      *
      * @return LocalContainerEntityManagerFactoryBean
-     * @throws ClassNotFoundException
-     *             when class not found
      */
     @Bean
     @DependsOn("flyway")


### PR DESCRIPTION
Updates OSLP code to be in-line with shared code after solving SonarQube
issues regarding exceptions in the CertificateHelper.

* SigningServerException is created for runtime EncrypterException
  instead of the general security exceptions that are no longer thrown
  by the CertificateHelper.
* ApplicationContext beans no longer throw exceptions on creation that
  should not occur.
* Changes anonymous ChannelPipelineFactory classes to lambdas to prevent
  a SonarQube major issue reporting this, that popped up after removing
  the declaration of checked exceptions that I think should not occur.