### PR TITLE
FLEX-4205 ~ Implements basic behavior for SetTransitionRequest for web-device-simulator.

### DIFF
--- a/web-device-simulator/src/main/java/com/alliander/osgp/webdevicesimulator/service/OslpChannelHandler.java
+++ b/web-device-simulator/src/main/java/com/alliander/osgp/webdevicesimulator/service/OslpChannelHandler.java
@@ -1035,13 +1035,13 @@ public class OslpChannelHandler extends SimpleChannelHandler {
         final String deviceId = device.getDeviceIdentification();
 
         if (TransitionType.DAY_NIGHT.equals(transitionType) && !device.isLightOn()) {
-            LOGGER.info("Switching relay on for device: {} after receiving transtion type: {}", deviceId,
+            LOGGER.info("Switching relay on for device: {} after receiving transition type: {}", deviceId,
                     transitionType);
             device.setLightOn(true);
             final Oslp.Event event = Oslp.Event.LIGHT_EVENTS_LIGHT_ON;
             this.sendEvent(device, event, description);
         } else if (TransitionType.NIGHT_DAY.equals(transitionType) && device.isLightOn()) {
-            LOGGER.info("Switching relay off for device: {} after receiving transtion type: {}", deviceId,
+            LOGGER.info("Switching relay off for device: {} after receiving transition type: {}", deviceId,
                     transitionType);
             device.setLightOn(false);
             final Oslp.Event event = Oslp.Event.LIGHT_EVENTS_LIGHT_OFF;


### PR DESCRIPTION
Use the transition type to determine if the relay should be switched on or off. Assume that the simulated device is running a 'normal' light schedule, meaning that the light is on during the night and off during the day.